### PR TITLE
Refactor all update functionality into item-specific classes

### DIFF
--- a/ruby/aged_brie_item.rb
+++ b/ruby/aged_brie_item.rb
@@ -1,0 +1,13 @@
+class AgedBrieItem < GenericItem
+  def initialize(item)
+    super(item)
+  end
+
+  def initial_quality_increment
+    @item.quality += 1 if @item.quality < 50
+  end
+
+  def post_quality_increment
+    @item.quality += 1 if (@item.sell_in < 0 && @item.quality < 50)
+  end
+end

--- a/ruby/backstage_passes_item.rb
+++ b/ruby/backstage_passes_item.rb
@@ -1,0 +1,17 @@
+class BackstagePassesItem < GenericItem
+  def initialize(item)
+    super(item)
+  end
+
+  def initial_quality_increment
+    if @item.quality < 50
+      @item.quality = @item.quality + 1
+      @item.quality += 1 if (@item.quality < 50 && @item.sell_in < 11)
+      @item.quality += 1 if (@item.quality < 50 && @item.sell_in < 6)
+    end
+  end
+
+  def post_quality_increment
+    @item.quality = 0 if @item.sell_in < 0
+  end
+end

--- a/ruby/conjured_item.rb
+++ b/ruby/conjured_item.rb
@@ -1,0 +1,23 @@
+class ConjuredItem < GenericItem
+  def initialize(item)
+    super(item)
+  end
+
+  def initial_quality_increment
+    if @item.quality == 1
+      @item.quality = 0
+    elsif @item.quality > 0
+      @item.quality -= 2
+    end
+  end
+
+  def post_quality_increment
+    if @item.sell_in < 0
+      if [1,2,3].include? @item.quality
+        @item.quality = 0
+      elsif @item.quality > 0
+        @item.quality -= 2
+      end
+    end
+  end
+end

--- a/ruby/generic_item.rb
+++ b/ruby/generic_item.rb
@@ -1,0 +1,35 @@
+class GenericItem
+  def initialize(item)
+    @item = item
+  end
+
+  def initial_quality_increment
+    @item.quality -= 1 if @item.quality > 0
+  end
+
+  def sell_in_increment
+    @item.sell_in -= 1
+  end
+
+  def post_quality_increment
+    @item.quality -= 1 if (@item.quality > 0 && @item.sell_in < 0)
+  end
+
+  def update
+    initial_quality_increment
+    sell_in_increment
+    post_quality_increment
+  end
+
+  def name
+    @item.name
+  end
+
+  def sell_in
+    @item.sell_in
+  end
+
+  def quality
+    @item.quality
+  end
+end

--- a/ruby/gilded_rose.rb
+++ b/ruby/gilded_rose.rb
@@ -1,72 +1,21 @@
 class GildedRose
-
   def initialize(items)
     @items = items
-  end
-
-  def update_aged_brie(item)
-    item.quality += 1 if item.quality < 50
-    
-    item.sell_in -= 1
-
-    item.quality += 1 if (item.sell_in < 0 && item.quality < 50)
-  end
-
-  def update_backstage_passes(item)
-    if item.quality < 50
-      item.quality = item.quality + 1
-      item.quality += 1 if (item.quality < 50 && item.sell_in < 11)
-      item.quality += 1 if (item.quality < 50 && item.sell_in < 6)
-    end
-
-    item.sell_in -= 1
-
-    item.quality = 0 if item.sell_in < 0
-  end
-  
-  def update_sulfuras(item)
-    item.sell_in -= 1
-  end
-
-  def update_conjured(item)
-    if item.quality == 1
-      item.quality = 0 
-    elsif item.quality > 0
-      item.quality -= 2
-    end    
-    
-    item.sell_in -= 1
-
-    if item.sell_in < 0
-      if [1,2,3].include? item.quality
-        item.quality = 0
-      elsif item.quality > 0
-        item.quality -= 2
-      end
-    end
-  end
-
-  def update_generic(item)
-    item.quality -= 1 if item.quality > 0
-
-    item.sell_in -= 1
-
-    item.quality -= 1 if (item.quality > 0 && item.sell_in < 0)
   end
 
   def update_quality
     @items.each do |item|
       case item.name
       when 'Aged Brie'
-        update_aged_brie(item)
+        ItemFactory.new(item).update
       when 'Backstage passes to a TAFKAL80ETC concert'
-        update_backstage_passes(item)
+        ItemFactory.new(item).update
       when 'Sulfuras, Hand of Ragnaros'
-        update_sulfuras(item)
+        ItemFactory.new(item).update
       when 'Conjured'
-        update_conjured(item)
+        ItemFactory.new(item).update
       else
-        update_generic(item)
+        ItemFactory.new(item).update
       end
     end
   end

--- a/ruby/gilded_rose_tests.rb
+++ b/ruby/gilded_rose_tests.rb
@@ -1,5 +1,11 @@
 require File.join(File.dirname(__FILE__), 'gilded_rose')
 require 'test/unit'
+require_relative 'item_factory'
+require_relative 'generic_item'
+require_relative 'aged_brie_item'
+require_relative 'backstage_passes_item'
+require_relative 'sulfuras_item'
+require_relative 'conjured_item'
 
 class TestGildedRose < Test::Unit::TestCase
   def test_foo

--- a/ruby/item_factory.rb
+++ b/ruby/item_factory.rb
@@ -1,0 +1,49 @@
+class ItemFactory
+  def initialize(item)
+    @initial_item = item
+    @item = determine_item_class(item).new(@initial_item)
+  end
+
+  def name
+    @item.name
+  end
+
+  def sell_in
+    @item.sell_in
+  end
+
+  def quality
+    @item.quality
+  end
+
+  def initial_quality_increment
+    @item.initial_quality_increment
+  end
+
+  def sell_in_increment
+    @item.sell_in_increment
+  end
+
+  def post_quality_increment
+    @item.post_quality_increment
+  end
+
+  def update
+    @item.update
+  end
+
+  def determine_item_class(item)
+    case item.name
+      when 'Aged Brie'
+        AgedBrieItem
+      when 'Backstage passes to a TAFKAL80ETC concert'
+        BackstagePassesItem
+      when 'Sulfuras, Hand of Ragnaros'
+        SulfurasItem
+      when 'Conjured'
+        ConjuredItem
+      else
+        GenericItem
+    end
+  end
+end

--- a/ruby/sulfuras_item.rb
+++ b/ruby/sulfuras_item.rb
@@ -1,0 +1,13 @@
+class SulfurasItem < GenericItem
+  def initialize(item)
+    super(item)
+  end
+
+  def initial_quality_increment
+    nil
+  end
+
+  def post_quality_increment
+    nil
+  end
+end


### PR DESCRIPTION
Previously our solution extracted update logic into methods on `GildedRose`, grouped by item 'type'. 

Now, we extract all update functionality into item-specific classes, and provide a delegating generic class to route updates based on item names. This leaves `GildedRose` totally agnostic to implementation details. 